### PR TITLE
Navbar good to go.

### DIFF
--- a/src/components/navbar/dropdown.astro
+++ b/src/components/navbar/dropdown.astro
@@ -1,6 +1,6 @@
 ---
 import { Dropdown, DropdownItems } from "astro-navbar";
-const { title, lastItem, children } = Astro.props;
+const { path, title, lastItem, children } = Astro.props;
 ---
 
 <li class="relative">
@@ -34,7 +34,7 @@ const { title, lastItem, children } = Astro.props;
           {
             children.map((item) => (
               <a
-                href={item.path}
+                href={`${path}/${item.slug}`}
                 class="py-1 text-gray-600 hover:text-gray-900">
                 {item.title}
               </a>

--- a/src/components/navbar/navbar.astro
+++ b/src/components/navbar/navbar.astro
@@ -13,9 +13,9 @@ const collectionGroupRecords = await getCollection("collection-group");
 const menuitems = [
   {
     title: "Collection Groups",
-    path: "/",
+    path: "/collection-group",
     children: collectionGroupRecords.map((r) => {
-      return { title: r.data.title };
+      return { title: r.data.title, slug: r.id };
     }),
   },
   {
@@ -33,7 +33,7 @@ const menuitems = [
   <header class="flex flex-col lg:flex-row justify-between items-center my-5">
     <Astronav>
       <div class="flex w-full lg:w-auto items-center justify-between">
-        <a href="/" class="text-lg font-semibold"
+        <a href="/" class="max-w-xs text-lg font-semibold"
           >{instanceVariables.projectTitle}
         </a>
         <div class="block lg:hidden">
@@ -47,6 +47,7 @@ const menuitems = [
               <>
                 {item.children && (
                   <Dropdown
+                    path={item.path}
                     title={item.title}
                     children={item.children}
                     lastItem={index === menuitems.length - 1}
@@ -66,10 +67,6 @@ const menuitems = [
             ))
           }
         </ul>
-        <div class="lg:hidden flex items-center mt-3 gap-4">
-          <Link href="#" style="muted" block size="md">Log in</Link>
-          <Link href="#" size="md" block>Sign up</Link>
-        </div>
       </MenuItems>
     </Astronav>
     <div>

--- a/src/content/collection-group/shipping.json
+++ b/src/content/collection-group/shipping.json
@@ -2,7 +2,7 @@
     "title": "Shipping and Containerization",
     "description": "Here are a few paragraphs about shipping and containerization. Hi ho hum. He ho hum hee.",
     "items": [
-        {"identifier": "commonwealth:3r077j844", "featured": true},
-        {"identifier": "commonwealth:9s161h27h", "featured": true}
+        "commonwealth:3r077j844",
+        "commonwealth:9s161h27h"
     ]
 }

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,8 +1,8 @@
 // 1. Import utilities from `astro:content`
-import { z, defineCollection } from 'astro:content';
+import { z, reference, defineCollection } from 'astro:content';
 
 // 2. Define your collection(s)
-const discoverCollection = defineCollection({
+const discover = defineCollection({
   schema: z.object({
     draft: z.boolean(),
     title: z.string(),
@@ -11,16 +11,17 @@ const discoverCollection = defineCollection({
   }),
 });
 
-const collectionGroupCollection = defineCollection({
+
+const itemCollection = defineCollection({
   type: "data",
   schema: z.object({
     title: z.string(),
     description: z.string(),
-    items: z.array(z.object({ "identifier": z.string(), "featured": z.boolean().optional() }))
+    items: z.array(reference('item'))
   }),
-});
+}); 
 
-const itemCollection = defineCollection({
+const item = defineCollection({
   type: "data",
   schema: z.object({
     itemType: z.enum(["digitalCommonwealth", "internetArchive"]),
@@ -31,7 +32,7 @@ const itemCollection = defineCollection({
 // 3. Export a single `collections` object to register your collection(s)
 //    This key should match your collection directory name in "src/content"
 export const collections = {
-  'discover': discoverCollection,
-  'collection-group': collectionGroupCollection,
-  'item': itemCollection
+  'discover': discover,
+  'collection-group': itemCollection,
+  'item': item
 };


### PR DESCRIPTION
This PR reflects the following changes:

+ Navbar up to spec, including...
  + Dropdown for each collections group that links to `/collection-group/[id]`, where `collection-group` path is passed to dropdown item by `path` prop, rather than hardcoded on element.
  + Multi-line logotype on the left.
  + Removed login, etc. buttons that were leftover from starting template.
+ Little tweak to collections schema, which makes use of Astro's `reference()` function to reduce duplicative objects between groups of items and and items. (Something like a PK-FK relationship between collections.)

I didn't touch the search, as @garrettdashnelson suggested that this will be milestone 2.