### PR TITLE
implement item thumbnail

### DIFF
--- a/src/components/collectioncard.astro
+++ b/src/components/collectioncard.astro
@@ -1,7 +1,7 @@
 ---
 import Card from "@components/card.astro"
 import { getEntries } from "astro:content";
-
+import ItemThumbnail from "@components/itemthumbnail.astro"
 const { item } = Astro.props;
 
 // Ideally, we'd want this, but getEntries doesn't accept filter functions.
@@ -10,15 +10,13 @@ const { item } = Astro.props;
 // });
 const collectionItems = await getEntries(item.data.items);
 
-console.log(collectionItems);
-
-const featuredItem = collectionItems.filter(function(i) {
+let featuredItem = collectionItems.filter(function(i) {
   return i.data.featured === true;
 })[0];
 
 ---
 <Card>
-    <img class="w-full" src="https://v1.tailwindcss.com/img/card-top.jpg"  alt=`Image from ${featuredItem.id}`>
+    <ItemThumbnail id={featuredItem.id} />
     {item.data.title && 
     <div class="p-4">
         <div class="text-gray-900 font-bold text-xl mb-2">

--- a/src/components/itemthumbnail.astro
+++ b/src/components/itemthumbnail.astro
@@ -1,0 +1,19 @@
+---
+const { id } = Astro.props;
+
+let title;
+
+async function getImageURL(id) {
+    const meta_endpoint = new URL(`https://collections.leventhalmap.org/search/${id}?format=json`)
+    const data = await fetch(meta_endpoint)
+        .then(response => response.json())
+    title = data.response.document.title_info_primary_tsi;
+    const exemplary_image = data.response.document.exemplary_image_ssi
+    const url = `https://bpldcassets.blob.core.windows.net/derivatives/images/${exemplary_image}/image_thumbnail_300.jpg`
+    return url
+}
+
+let data = await getImageURL(id);
+---
+
+<img class="w-full" src={data}  alt=`Image from ${title}`>


### PR DESCRIPTION
Creates `itemthumbnail` component that pulls exemplary image identifier for a given item from its metadata and constructs `src` URL for `<img ...>`