### PR TITLE
reschematize featured items, build custom zod validator

### DIFF
--- a/src/components/collectioncard.astro
+++ b/src/components/collectioncard.astro
@@ -4,14 +4,10 @@ import { getEntries } from "astro:content";
 import ItemThumbnail from "@components/itemthumbnail.astro"
 const { item } = Astro.props;
 
-// Ideally, we'd want this, but getEntries doesn't accept filter functions.
-// const collectionItems = await getEntries(items, ({ data }) => {
-//  return data.featured === true;
-// });
 const collectionItems = await getEntries(item.data.items);
 
 let featuredItem = collectionItems.filter(function(i) {
-  return i.data.featured === true;
+  return i.id === item.data.featured.id
 })[0];
 
 ---

--- a/src/content/collection-group/architectural-plans.json
+++ b/src/content/collection-group/architectural-plans.json
@@ -4,5 +4,6 @@
     "items": [
         "commonwealth:7h14cx85q",
         "commonwealth:9s161h27h"
-    ]
+    ],
+    "featured": "commonwealth:7h14cx85q"
 }

--- a/src/content/collection-group/labor.json
+++ b/src/content/collection-group/labor.json
@@ -4,5 +4,6 @@
     "items": [
         "commonwealth:3r077j844",
         "commonwealth:9s161h27h"
-    ]
+    ],
+    "featured": "commonwealth:3r077j844"
 }

--- a/src/content/collection-group/shipping.json
+++ b/src/content/collection-group/shipping.json
@@ -4,5 +4,6 @@
     "items": [
         "commonwealth:3r077j844",
         "commonwealth:9s161h27h"
-    ]
+    ],
+    "featured": "commonwealth:9s161h27h"
 }

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -17,8 +17,19 @@ const itemCollection = defineCollection({
   schema: z.object({
     title: z.string(),
     description: z.string(),
-    items: z.array(reference('item'))
-  }),
+    items: z.array(reference('item')),
+    featured: reference('item')
+  }).superRefine(
+    ({items, featured}, ctx) => {
+      if (!items.map((d) => d.id).includes(featured.id)) {
+        ctx.addIssue({
+          code: "custom",
+          message: "`featured` must be included in `items`",
+          path: ["featured"]
+        })
+      }
+    }
+  ),
 }); 
 
 const item = defineCollection({

--- a/src/content/item/commonwealth:3r077j844.json
+++ b/src/content/item/commonwealth:3r077j844.json
@@ -1,5 +1,4 @@
 {
     "itemType": "digitalCommonwealth",
-    "tags": ["T Wharf", "color photographs"],
-    "featured": true
+    "tags": ["T Wharf", "color photographs"]
 }

--- a/src/content/item/commonwealth:7h14cx85q.json
+++ b/src/content/item/commonwealth:7h14cx85q.json
@@ -1,5 +1,4 @@
 { 
     "itemType": "digitalCommonwealth",
-    "tags": ["BRA", "Sasaki"],
-    "featured": true
+    "tags": ["BRA", "Sasaki"]
 }

--- a/src/content/item/commonwealth:9s161h27h.json
+++ b/src/content/item/commonwealth:9s161h27h.json
@@ -1,5 +1,4 @@
 { 
     "itemType": "digitalCommonwealth",
-    "tags": ["surveyor plans"],
-    "featured": false
+    "tags": ["surveyor plans"]
 }


### PR DESCRIPTION
New schema for collections (boolean `featured` removed from items: 

```js
{
    "title": "Shipping and Containerization",
    "description": "Here are a few paragraphs about shipping and containerization. Hi ho hum. He ho hum hee.",
    "items": [
        "commonwealth:3r077j844",
        "commonwealth:9s161h27h"
    ],
    "featured": "commonwealth:9s161h27h" // <- must be present in items
}
```

Custom validator that checks whether `featured` `item` is present in `items`:

```js
  schema: z.object({
    title: z.string(),
    description: z.string(),
    items: z.array(reference('item')),
    featured: reference('item')
  }).superRefine(
    ({items, featured}, ctx) => {
      if (!items.map((d) => d.id).includes(featured.id)) {
        ctx.addIssue({
          code: "custom",
          message: "`featured` must be included in `items`",
          path: ["featured"]
        })
      }
  }),
```